### PR TITLE
Plat 458 - Query builder - another attempt

### DIFF
--- a/subconscious/model.py
+++ b/subconscious/model.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 
 from .column import Column
+from .query import Query
 
 
 logger = logging.getLogger(__name__)
@@ -336,3 +337,7 @@ class RedisModel(object, metaclass=ModelMeta):
         for key in await cls._get_ids_filter_by(db, **kwargs):
             return await cls.load(db, key)
         return None
+
+    @classmethod
+    def query(cls, db) -> Query:
+        return Query(model=cls, db=db)

--- a/subconscious/query.py
+++ b/subconscious/query.py
@@ -9,8 +9,10 @@ class Query(object):
         return self
 
     def __aiter__(self):
-        self.result_set = self._model.filter_by(db=self._db, **self._filter) \
-            if self._filter else self._model.all(db=self._db)
+        if self._filter:
+            self.result_set = self._model.filter_by(db=self._db, **self._filter)
+        else:
+            self.result_set = self._model.all(db=self._db)
         return self
 
     async def __anext__(self):

--- a/subconscious/query.py
+++ b/subconscious/query.py
@@ -1,0 +1,23 @@
+class Query(object):
+    def __init__(self, model, db):
+        self._model = model
+        self._filter = {}
+        self._db = db
+
+    async def first(self):
+        if self._filter:
+            return await self._model.get_object_or_none(db=self._db, **self._filter)
+        else:
+            async for x in self._model.all(db=self._db, limit=1):
+                return x
+        return None
+
+    def filter(self, **kwargs):
+        self._filter.update(kwargs)
+        return self
+
+    def execute(self):
+        if self._filter:
+            return self._model.filter_by(db=self._db, **self._filter)
+        else:
+            return self._model.all(db=self._db)

--- a/subconscious/query.py
+++ b/subconscious/query.py
@@ -4,6 +4,20 @@ class Query(object):
         self._filter = {}
         self._db = db
 
+    def filter(self, **kwargs):
+        self._filter.update(kwargs)
+        return self
+
+    def __aiter__(self):
+        self.result_set = self._model.filter_by(db=self._db, **self._filter) \
+            if self._filter else self._model.all(db=self._db)
+        return self
+
+    async def __anext__(self):
+        async for x in self.result_set:
+            return x
+        raise StopAsyncIteration
+
     async def first(self):
         if self._filter:
             return await self._model.get_object_or_none(db=self._db, **self._filter)
@@ -11,13 +25,3 @@ class Query(object):
             async for x in self._model.all(db=self._db, limit=1):
                 return x
         return None
-
-    def filter(self, **kwargs):
-        self._filter.update(kwargs)
-        return self
-
-    def execute(self):
-        if self._filter:
-            return self._model.filter_by(db=self._db, **self._filter)
-        else:
-            return self._model.all(db=self._db)

--- a/tests/test_filter_by.py
+++ b/tests/test_filter_by.py
@@ -17,21 +17,6 @@ class TestUser(RedisModel):
     status = Column(type=str, enum=StatusEnum, index=True)
 
 
-class TestIter(object):
-
-    def __init__(self, db):
-        self.db = db
-
-    def __aiter__(self):
-        self.gen = TestUser.all(db=self.db)
-        return self
-
-    async def __anext__(self):
-        async for x in self.gen:
-            return x
-        raise StopAsyncIteration()
-
-
 class TestFilterBy(BaseTestCase):
     def setUp(self):
         super(TestFilterBy, self).setUp()

--- a/tests/test_filter_by.py
+++ b/tests/test_filter_by.py
@@ -94,3 +94,11 @@ class TestFilterBy(BaseTestCase):
             self.assertEqual(TestUser, type(user))
             self.assertEqual(user.status, 'active')
         self.loop.run_until_complete(_test())
+
+    def test_query_chaining_filters(self):
+        async def _test():
+            user = await TestUser.query(db=self.db).filter(name='name-1').filter(status='active').first()
+            self.assertEqual(TestUser, type(user))
+            self.assertEqual(user.status, 'active')
+            self.assertEqual(user.name, 'name-1')
+        self.loop.run_until_complete(_test())

--- a/tests/test_filter_by.py
+++ b/tests/test_filter_by.py
@@ -64,3 +64,33 @@ class TestFilterBy(BaseTestCase):
                 result_list.append(x)
             self.assertEqual(1, len(result_list))
         self.loop.run_until_complete(_test())
+
+    def test_query(self):
+        async def _test():
+            result_list = []
+            async for x in TestUser.query(db=self.db).filter(status='active').execute():
+                result_list.append(x)
+            self.assertEqual(10, len(result_list))
+        self.loop.run_until_complete(_test())
+
+    def test_query_no_filter(self):
+        async def _test():
+            result_list = []
+            async for x in TestUser.query(db=self.db).execute():
+                result_list.append(x)
+            self.assertEqual(10, len(result_list))
+        self.loop.run_until_complete(_test())
+
+    def test_query_first(self):
+        async def _test():
+            user = await TestUser.query(db=self.db).filter(status='active').first()
+            self.assertEqual(TestUser, type(user))
+            self.assertEqual(user.status, 'active')
+        self.loop.run_until_complete(_test())
+
+    def test_query_first_no_filter(self):
+        async def _test():
+            user = await TestUser.query(db=self.db).first()
+            self.assertEqual(TestUser, type(user))
+            self.assertEqual(user.status, 'active')
+        self.loop.run_until_complete(_test())


### PR DESCRIPTION
@mflaxman 
Made Query a proper iterator, Now we can lazily iterate over it. No need of execute method, removed it. Not supporting 'order_by' yet as we don't have support for 'order_by' in our filter_by method. Adding 'order_by' can be a separate PR , you are welcome to contribute.
Examples:
```
If you want to lazily iterate over all Users:
async for x in User.query(db=db):
  print(x.as_dict())
# Only Active users 
async for x in User.query(db=db).filter(status='active'):
  print(x.as_dict())

# Conditional query building:
q = User.query(db=db)
if 'status' in params:
  q.filter(status=params['status']
if 'name ' in params:
  q.filter(name=params['name'])
# Now iterate
async for x in q:
  print(x.as_dict())

```
