### PR TITLE
PLAT-593 - support bytes fields

### DIFF
--- a/subconscious/column.py
+++ b/subconscious/column.py
@@ -18,7 +18,7 @@ class Column(object):
         You can't have both a primary_key and composite_key in the same model.
         index is whether you want this column indexed or not for faster retrieval.
         """
-        if type not in (str, int):
+        if type not in (str, int, bytes):
             # TODO: support for other field types (datetime, uuid, etc)
             err_msg = 'Bad Field Type: {}'.format(type)
             raise InvalidColumnDefinition(err_msg)

--- a/subconscious/model.py
+++ b/subconscious/model.py
@@ -234,6 +234,8 @@ class RedisModel(object, metaclass=ModelMeta):
                 column = getattr(cls, key, False)
                 if not column or (column.field_type == str):
                     kwargs[key] = value
+                elif column.field_type == bytes:
+                    kwargs[key] = column.field_type(value, 'utf-8')
                 else:
                     kwargs[key] = column.field_type(value)
             kwargs['loading'] = True

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -14,6 +14,7 @@ class TestUser(RedisModel):
     age = Column(index=True, type=int,)
     locale = Column(index=True, type=int, required=False)
     status = Column(type=str, enum=StatusEnum)
+    data_blob = Column(type=bytes)
 
 
 class TestAll(BaseTestCase):
@@ -21,7 +22,7 @@ class TestAll(BaseTestCase):
     def setUp(self):
         super(TestAll, self).setUp()
         user_id = str(uuid1())
-        user = TestUser(id=user_id, name='Test name', age=100, status='active')
+        user = TestUser(id=user_id, name='Test name', age=100, status='active', data_blob=b'{\'foo\': \'bar\'}')
         ret = self.loop.run_until_complete(user.save(self.db))
         self.assertTrue(ret)
 


### PR DESCRIPTION
Support bytes fields. This is needed in order to store opaque trade metadata as bytes.