### PR TITLE
Add support for datetime.

### DIFF
--- a/subconscious/column.py
+++ b/subconscious/column.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from datetime import datetime
 from enum import EnumMeta
 
 
@@ -18,8 +19,8 @@ class Column(object):
         You can't have both a primary_key and composite_key in the same model.
         index is whether you want this column indexed or not for faster retrieval.
         """
-        if type not in (str, int):
-            # TODO: support for other field types (datetime, uuid, etc)
+        if type not in (str, int, datetime):
+            # TODO: support for other field types (uuid, etc)
             err_msg = 'Bad Field Type: {}'.format(type)
             raise InvalidColumnDefinition(err_msg)
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,5 +1,6 @@
 from subconscious.model import RedisModel, Column, InvalidQuery
 from uuid import uuid1
+from datetime import datetime
 from .base import BaseTestCase
 import enum
 
@@ -14,6 +15,7 @@ class TestUser(RedisModel):
     age = Column(index=True, type=int,)
     locale = Column(index=True, type=int, required=False)
     status = Column(type=str, enum=StatusEnum)
+    birth_date = Column(type=datetime, required=False)
 
 
 class TestAll(BaseTestCase):
@@ -26,7 +28,8 @@ class TestAll(BaseTestCase):
         self.assertTrue(ret)
 
         user_id = str(uuid1())
-        user1 = TestUser(id=user_id, name='ZTest name', age=53)
+        bdate = datetime(1854, 1, 6, 14, 35, 19)
+        user1 = TestUser(id=user_id, name='ZTest name', age=53, birth_date=bdate)
         ret = self.loop.run_until_complete(user1.save(self.db))
         self.assertTrue(ret)
 
@@ -41,6 +44,9 @@ class TestAll(BaseTestCase):
                 self.assertEqual(type(x), TestUser)
                 self.assertTrue(x.name in ('Test name', 'ZTest name', 'Test name2'))
                 self.assertTrue(x.age in (100, 53))
+                if x.name == 'ZTest name':
+                    bdate = datetime(1854, 1, 6, 14, 35, 19)
+                    self.assertEqual(x.birth_date, bdate)
         self.loop.run_until_complete(_test_all())
 
     def test_all_with_order(self):


### PR DESCRIPTION
Pretty much what it says in the title. After this patch, you can use `datetime.datetime` as a column type. The dates are serialized into strings on `save` using `strftime`, and then read back on `load` using `strptime`. Pretty simple. Time-zone info is lost however, due the fact that there is no easy way to use `strptime` and `strftime` in such a way that both datetimes with and without time-zones are supported.